### PR TITLE
feat: get quotes

### DIFF
--- a/src/modules/quotes/__tests__/unit/services/quotes.facade.spec.ts
+++ b/src/modules/quotes/__tests__/unit/services/quotes.facade.spec.ts
@@ -4,6 +4,7 @@ import { QuotesService } from '../../../services/quotes.service';
 import { CreateQuoteDto } from '../../../dto/create-quote.dto';
 import { Currency } from '../../../interfaces/currency.enum';
 import { IQuoteResponse } from '../../../interfaces/quote.interface';
+import { QuoteEntity } from '../../../entities/quote.entity';
 
 describe('QuotesFacade', () => {
   let facade: QuotesFacade;
@@ -11,6 +12,9 @@ describe('QuotesFacade', () => {
 
   const mockQuotesService = {
     createQuote: jest.fn(),
+    getQuoteById: jest.fn(),
+    getAllCurrencies: jest.fn(),
+    getUserQuotes: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -73,6 +77,101 @@ describe('QuotesFacade', () => {
         createQuoteDto,
         userId,
       );
+    });
+  });
+
+  describe('getQuoteById', () => {
+    const quoteId = 1;
+    const mockQuoteResponse: IQuoteResponse = {
+      id: quoteId,
+      from: Currency.ARS,
+      to: Currency.ETH,
+      amount: 1000000,
+      rate: 0.0000023,
+      convertedAmount: 2.3,
+      timestamp: new Date(),
+      expiresAt: new Date(new Date().getTime() + 5 * 60000),
+    };
+
+    it('should delegate to QuotesService.getQuoteById and return the result', async () => {
+      mockQuotesService.getQuoteById.mockResolvedValue(mockQuoteResponse);
+
+      const result = await facade.getQuoteById(quoteId);
+
+      expect(result).toEqual(mockQuoteResponse);
+      expect(mockQuotesService.getQuoteById).toHaveBeenCalledWith(quoteId);
+    });
+
+    it('should throw any errors from QuotesService', async () => {
+      const error = new Error('Quote not found');
+      mockQuotesService.getQuoteById.mockRejectedValue(error);
+
+      await expect(facade.getQuoteById(quoteId)).rejects.toThrow(error);
+
+      expect(mockQuotesService.getQuoteById).toHaveBeenCalledWith(quoteId);
+    });
+  });
+
+  describe('getAllCurrencies', () => {
+    const mockCurrencies = Object.values(Currency);
+
+    it('should delegate to QuotesService.getAllCurrencies and return the result', async () => {
+      mockQuotesService.getAllCurrencies.mockResolvedValue(mockCurrencies);
+
+      const result = await facade.getAllCurrencies();
+
+      expect(result).toEqual(mockCurrencies);
+      expect(mockQuotesService.getAllCurrencies).toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserQuotes', () => {
+    const userId = 1;
+    const mockQuotes: QuoteEntity[] = [
+      new QuoteEntity({
+        id: 1,
+        from: Currency.ARS,
+        to: Currency.ETH,
+        amount: 1000000,
+        rate: 0.0000023,
+        convertedAmount: 2.3,
+        timestamp: new Date(),
+        expiresAt: new Date(new Date().getTime() + 5 * 60000),
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      new QuoteEntity({
+        id: 2,
+        from: Currency.ETH,
+        to: Currency.BTC,
+        amount: 1,
+        rate: 0.05,
+        convertedAmount: 0.05,
+        timestamp: new Date(),
+        expiresAt: new Date(new Date().getTime() + 5 * 60000),
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ];
+
+    it('should delegate to QuotesService.getUserQuotes and return the result', async () => {
+      mockQuotesService.getUserQuotes.mockResolvedValue(mockQuotes);
+
+      const result = await facade.getUserQuotes(userId);
+
+      expect(result).toEqual(mockQuotes);
+      expect(mockQuotesService.getUserQuotes).toHaveBeenCalledWith(userId);
+    });
+
+    it('should throw any errors from QuotesService', async () => {
+      const error = new Error('Failed to get user quotes');
+      mockQuotesService.getUserQuotes.mockRejectedValue(error);
+
+      await expect(facade.getUserQuotes(userId)).rejects.toThrow(error);
+
+      expect(mockQuotesService.getUserQuotes).toHaveBeenCalledWith(userId);
     });
   });
 });

--- a/src/modules/quotes/controllers/quotes.controller.ts
+++ b/src/modules/quotes/controllers/quotes.controller.ts
@@ -5,22 +5,30 @@ import {
   UseGuards,
   Request,
   UnauthorizedException,
+  Get,
+  Param,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { QuotesFacade } from '../services/quotes.facade';
 import { CreateQuoteDto } from '../dto/create-quote.dto';
 import { AuthGuard } from '../../auth/guards/auth.guard';
-import { ApiCreateQuote } from '../swagger';
+import {
+  ApiCreateQuote,
+  ApiGetQuoteById,
+  ApiGetAllCurrencies,
+  ApiGetUserQuotes,
+} from '../swagger';
 
 @ApiTags('Cotizaciones')
 @ApiBearerAuth()
 @Controller('quote')
-@UseGuards(AuthGuard)
 export class QuotesController {
   constructor(private readonly quotesFacade: QuotesFacade) {}
 
   @Post()
   @ApiCreateQuote()
+  @UseGuards(AuthGuard)
   async create(@Body() createQuoteDto: CreateQuoteDto, @Request() req) {
     if (!req.user) {
       throw new UnauthorizedException('Usuario no autenticado');
@@ -35,5 +43,37 @@ export class QuotesController {
     }
 
     return this.quotesFacade.createQuote(createQuoteDto, userId);
+  }
+
+  @Get(':id')
+  @ApiGetQuoteById()
+  @UseGuards(AuthGuard)
+  async getQuoteById(@Param('id', ParseIntPipe) id: number) {
+    return this.quotesFacade.getQuoteById(id);
+  }
+
+  @Get('currencies/all')
+  @ApiGetAllCurrencies()
+  async getAllCurrencies() {
+    return this.quotesFacade.getAllCurrencies();
+  }
+
+  @Get('user/all')
+  @ApiGetUserQuotes()
+  @UseGuards(AuthGuard)
+  async getUserQuotes(@Request() req) {
+    if (!req.user) {
+      throw new UnauthorizedException('Usuario no autenticado');
+    }
+
+    const userId = req.user.id || req.user.sub;
+
+    if (!userId) {
+      throw new UnauthorizedException(
+        'No se pudo determinar el ID del usuario',
+      );
+    }
+
+    return this.quotesFacade.getUserQuotes(userId);
   }
 }

--- a/src/modules/quotes/services/quotes.facade.ts
+++ b/src/modules/quotes/services/quotes.facade.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { QuotesService } from './quotes.service';
 import { CreateQuoteDto } from '../dto/create-quote.dto';
 import { IQuoteResponse } from '../interfaces/quote.interface';
+import { Currency } from '../interfaces/currency.enum';
+import { QuoteEntity } from '../entities/quote.entity';
 
 @Injectable()
 export class QuotesFacade {
@@ -12,5 +14,17 @@ export class QuotesFacade {
     userId: number,
   ): Promise<IQuoteResponse> {
     return this.quotesService.createQuote(createQuoteDto, userId);
+  }
+
+  async getQuoteById(id: number): Promise<IQuoteResponse | null> {
+    return this.quotesService.getQuoteById(id);
+  }
+
+  async getAllCurrencies(): Promise<Currency[]> {
+    return this.quotesService.getAllCurrencies();
+  }
+
+  async getUserQuotes(userId: number): Promise<QuoteEntity[]> {
+    return this.quotesService.getUserQuotes(userId);
   }
 }

--- a/src/modules/quotes/services/quotes.service.ts
+++ b/src/modules/quotes/services/quotes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
 import { QuotesRepository } from '../repositories/quotes.repository';
 import { CreateQuoteDto } from '../dto/create-quote.dto';
 import {
@@ -11,6 +11,8 @@ import {
   IExchangeRateApi,
   EXCHANGE_RATE_API,
 } from '../infrastructure/api/exchange-rate-api.interface';
+import { Currency } from '../interfaces/currency.enum';
+import { QuoteEntity } from '../entities/quote.entity';
 
 @Injectable()
 export class QuotesService {
@@ -63,5 +65,29 @@ export class QuotesService {
 
       throw new QuoteCreationFailedException();
     }
+  }
+
+  async getQuoteById(id: number): Promise<IQuoteResponse | null> {
+    const quote = await this.quotesRepository.findById(id);
+
+    if (!quote) {
+      throw new NotFoundException(`Cotización con ID ${id} no encontrada`);
+    }
+
+    const now = new Date();
+    if (now > quote.expiresAt) {
+      throw new NotFoundException(`La cotización con ID ${id} ha expirado`);
+    }
+
+    const { userId, createdAt, updatedAt, ...result } = quote;
+    return result;
+  }
+
+  async getAllCurrencies(): Promise<Currency[]> {
+    return Object.values(Currency);
+  }
+
+  async getUserQuotes(userId: number): Promise<QuoteEntity[]> {
+    return this.quotesRepository.findByUserId(userId);
   }
 }

--- a/src/modules/quotes/swagger/quote.decorator.ts
+++ b/src/modules/quotes/swagger/quote.decorator.ts
@@ -7,6 +7,7 @@ import {
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
   ApiInternalServerErrorResponse,
+  ApiParam,
 } from '@nestjs/swagger';
 import { CreateQuoteDto } from '../dto/create-quote.dto';
 import { QuoteResponseSchema } from './quote.schema';
@@ -136,6 +137,137 @@ export const ApiCreateQuote = () => {
           error: 'Internal Server Error',
         },
       },
+    }),
+  );
+};
+
+export const ApiGetQuoteById = () => {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: 'Obtener una cotización por ID',
+      description:
+        'Recupera una cotización existente por su ID, validando que no haya expirado',
+    }),
+    ApiParam({
+      name: 'id',
+      type: 'number',
+      description: 'ID de la cotización a recuperar',
+      required: true,
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Cotización recuperada exitosamente',
+      type: QuoteResponseSchema,
+      schema: {
+        example: {
+          id: 1,
+          from: 'ARS',
+          to: 'ETH',
+          amount: 1000000,
+          rate: 0.0000023,
+          convertedAmount: 2.3,
+          timestamp: '2025-02-03T12:00:00Z',
+          expiresAt: '2025-02-03T12:05:00Z',
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Cotización no encontrada o expirada',
+      schema: {
+        example: {
+          statusCode: 404,
+          message: 'La cotización con ID 1 no encontrada',
+          error: 'Not Found',
+        },
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'No autorizado - Token no proporcionado o inválido',
+    }),
+  );
+};
+
+export const ApiGetAllCurrencies = () => {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: 'Obtener todas las monedas disponibles',
+      description:
+        'Devuelve la lista de todas las monedas soportadas por el sistema',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Lista de monedas disponibles',
+      schema: {
+        example: [
+          'ARS',
+          'ETH',
+          'BTC',
+          'USDT',
+          'XEM',
+          'CLP',
+          'SHIB',
+          'DOGE',
+          'XLM',
+        ],
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'No autorizado - Token no proporcionado o inválido',
+    }),
+  );
+};
+
+export const ApiGetUserQuotes = () => {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: 'Obtener todas las cotizaciones del usuario',
+      description:
+        'Recupera todas las cotizaciones asociadas al usuario autenticado',
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Lista de cotizaciones del usuario',
+      schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', example: 1 },
+            from: { type: 'string', example: 'ARS' },
+            to: { type: 'string', example: 'ETH' },
+            amount: { type: 'number', example: 1000000 },
+            rate: { type: 'number', example: 0.0000023 },
+            convertedAmount: { type: 'number', example: 2.3 },
+            timestamp: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-02-03T12:00:00Z',
+            },
+            expiresAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-02-03T12:05:00Z',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-02-03T12:00:00Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-02-03T12:00:00Z',
+            },
+          },
+        },
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'No autorizado - Token no proporcionado o inválido',
     }),
   );
 };


### PR DESCRIPTION
# Summary
Added three new endpoints to the Quote module for retrieving quote details, listing available currencies, and fetching user quotes, along with comprehensive test coverage.

# Details
* `GET /quote/:id` - Retrieves quote details by ID, verifying the quote hasn't expired
* `GET /quote/currencies/all` - Returns all available currencies from the Currency enum
*  `GET /quote/user/all` - Fetches all quotes associated with the authenticated user